### PR TITLE
fix(stdio_acp): use idle timeout instead of total timeout

### DIFF
--- a/iflow_bot/engine/stdio_acp.py
+++ b/iflow_bot/engine/stdio_acp.py
@@ -529,12 +529,14 @@ class StdioACPClient:
         
         try:
             timeout = timeout or self.timeout
-            start_time = asyncio.get_running_loop().time()
+            # 使用空闲超时：每次收到消息后重置计时器
+            # 这样长时间生成内容不会触发超时，只有真正卡住才会超时
+            last_activity_time = asyncio.get_running_loop().time()
             
             while True:
-                remaining = timeout - (asyncio.get_running_loop().time() - start_time)
-                if remaining <= 0:
-                    raise StdioACPTimeoutError("Prompt timeout")
+                idle_time = asyncio.get_running_loop().time() - last_activity_time
+                if idle_time >= timeout:
+                    raise StdioACPTimeoutError("Prompt timeout (idle)")
                 
                 try:
                     if future.done():
@@ -546,12 +548,15 @@ class StdioACPClient:
                             session_queue.get(),
                             timeout=0.1
                         )
+                        last_activity_time = asyncio.get_running_loop().time()  # 收到消息，重置计时器
                     except asyncio.TimeoutError:
                         # 尝试从全局队列获取（如果没有 sessionId 字段）
+                        remaining_idle = timeout - idle_time
                         msg = await asyncio.wait_for(
                             self._message_queue.get(),
-                            timeout=min(remaining, 4.9)
+                            timeout=min(remaining_idle, 4.9)
                         )
+                        last_activity_time = asyncio.get_running_loop().time()  # 收到消息，重置计时器
                     
                     if msg.get("method") == "session/update":
                         params = msg.get("params", {})


### PR DESCRIPTION
 ## 问题

   原来的超时逻辑从发送消息开始计时，而不是从最后一次活动开始计时。

   当 iflow 生成内容需要较长时间（但仍在持续输出）时，会触发超时，导致会话重建和上下文丢失。

   这解释了用户在 #17 报告的"跨版本反复出现的问题"。

   ---

   ## Problem

   The original timeout logic counts from when the message is sent, not from the last activity.

   When iflow takes a long time to generate content (but is still actively outputting), it triggers a timeout, causing session recreation and context loss.

   This explains the "recurring issue across versions" reported in #17.

   ---

   ## 解决方案

   将"总超时"改为"空闲超时"（idle timeout）：

   - 每次收到消息/chunk 后重置计时器
   - 只要 iflow 持续输出，就不会超时
   - 只有真正卡住（无输出超过 timeout 秒）才会触发超时

   ---

   ## Solution

   Changed from "total timeout" to "idle timeout":

   - Reset timer on each message/chunk received
   - As long as iflow keeps outputting, no timeout occurs
   - Only times out when truly stuck (no output for `timeout` seconds)

   ---

   ## 效果

   - ✅ 长时间生成内容不再触发超时
   - ✅ 保留了对真正卡住会话的保护机制
   - ✅ 修复 #17

   ---

   ## Effect

   - ✅ Long content generation no longer triggers timeout
   - ✅ Still protects against truly stuck sessions
   - ✅ Fixes #17