### PR TITLE
fix: 不再自动修改用户配置的超时时间

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Configuration file located at `~/.iflow-bot/config.json`
     "yolo": true,
     "thinking": false,
     "max_turns": 40,
-    "timeout": 180,
+    "timeout": 300,
     "workspace": "~/.iflow-bot/workspace",
     "extra_args": []
   },
@@ -263,7 +263,7 @@ Configuration file located at `~/.iflow-bot/config.json`
 | `yolo` | bool | `true` | Auto-confirm mode |
 | `thinking` | bool | `false` | Show AI thinking process |
 | `max_turns` | int | `40` | Maximum conversation turns per session |
-| `timeout` | int | `180` | Timeout in seconds |
+| `timeout` | int | `300` | Timeout in seconds |
 | `workspace` | string | `~/.iflow-bot/workspace` | Workspace path |
 | `extra_args` | list | `[]` | Additional iflow arguments |
 | `acp_port` | int | `8090` | Port for ACP mode |

--- a/README_CN.md
+++ b/README_CN.md
@@ -171,7 +171,7 @@ docker compose logs -f iflow-bot
     "yolo": true,
     "thinking": false,
     "max_turns": 40,
-    "timeout": 180,
+    "timeout": 300,
     "workspace": "~/.iflow-bot/workspace",
     "extra_args": []
   },
@@ -263,7 +263,7 @@ docker compose logs -f iflow-bot
 | `yolo` | bool | `true` | 自动确认模式 |
 | `thinking` | bool | `false` | 显示 AI 思考过程 |
 | `max_turns` | int | `40` | 单次最大对话轮次 |
-| `timeout` | int | `180` | 超时时间（秒） |
+| `timeout` | int | `300` | 超时时间（秒） |
 | `workspace` | string | `~/.iflow-bot/workspace` | 工作空间路径 |
 | `extra_args` | list | `[]` | 额外的 iflow 参数 |
 | `acp_port` | int | `8090` | ACP 模式下的端口号 |

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -6,7 +6,7 @@
     "yolo": true,
     "thinking": false,
     "max_turns": 40,
-    "timeout": 180,
+    "timeout": 300,
     "workspace": "/root/.iflow-bot/workspace",
     "extra_args": []
   },

--- a/iflow_bot/config/loader.py
+++ b/iflow_bot/config/loader.py
@@ -10,8 +10,7 @@ from loguru import logger
 from iflow_bot.config.schema import Config
 
 # 统一的超时常量定义
-DEFAULT_TIMEOUT = 180  # 默认超时时间（秒）
-LEGACY_DEFAULT_TIMEOUT = 300  # 旧版默认值，用于迁移检测
+DEFAULT_TIMEOUT = 300  # 默认超时时间（秒）
 
 
 def get_config_dir() -> Path:
@@ -80,12 +79,9 @@ def load_config(config_path: Optional[Path] = None, auto_create: bool = True) ->
 
 
 def _migrate_legacy_driver_timeout(data: dict) -> tuple[dict, bool]:
-    """Migrate legacy default timeout to new default for upgraded users.
+    """确保配置中有 timeout 字段。
 
-    Rules:
-    - If `driver.timeout` is missing, set it to DEFAULT_TIMEOUT.
-    - If `driver.timeout` equals legacy default 300 (int or string), set to DEFAULT_TIMEOUT.
-    - Keep all other custom timeout values unchanged.
+    只在 timeout 缺失时设置默认值，不修改用户已有的配置。
     """
     migrated = False
     driver = data.get("driver")
@@ -94,9 +90,6 @@ def _migrate_legacy_driver_timeout(data: dict) -> tuple[dict, bool]:
 
     timeout = driver.get("timeout")
     if timeout is None:
-        driver["timeout"] = DEFAULT_TIMEOUT
-        migrated = True
-    elif timeout == LEGACY_DEFAULT_TIMEOUT or timeout == str(LEGACY_DEFAULT_TIMEOUT):
         driver["timeout"] = DEFAULT_TIMEOUT
         migrated = True
 


### PR DESCRIPTION
## 问题

用户反馈：手动将 `timeout` 改为 300 秒后，每次启动程序都会被自动改回 180 秒。

## 原因

PR [#16](https://github.com/kai648846760/iflow-bot/pull/16) 引入的迁移逻辑错误地将配置文件中的 `timeout=300` 当作"旧版默认值"自动迁移到 180 秒，没有正确识别这可能是用户主动配置的值。

## 修复

- 移除对 `timeout=300` 的自动迁移，只在配置缺失 timeout 字段时才设置默认值
- 将默认超时时间从 180 秒调整为 300 秒（iFlow 模型响应变慢，180秒太短太激进了，不是一个合适的时间）

## 改动

- 删除 `LEGACY_DEFAULT_TIMEOUT` 常量
- 简化 `_migrate_legacy_driver_timeout()` 函数
- 更新 `DEFAULT_TIMEOUT` 为 300
- 更新文档和示例配置