### PR TITLE
Fix cron service restart issues (next run time & file watcher lifecycle)

### DIFF
--- a/iflow_bot/cron/service.py
+++ b/iflow_bot/cron/service.py
@@ -324,7 +324,11 @@ class CronService:
     
     def list_jobs(self, include_disabled: bool = False) -> list[CronJob]:
         """List all jobs."""
+        # Force reload from disk to get fresh data (important for CLI commands like cron list)
+        self._store = None
         store = self._load_store()
+        # Recompute next run times to ensure accurate display after gateway restart
+        self._recompute_next_runs()
         jobs = store.jobs if include_disabled else [j for j in store.jobs if j.enabled]
         return sorted(jobs, key=lambda j: j.state.next_run_at_ms or float('inf'))
     

--- a/iflow_bot/cron/service.py
+++ b/iflow_bot/cron/service.py
@@ -134,7 +134,7 @@ class CronService:
     ):
         """
         Initialize the cron service.
-        
+
         Args:
             store_path: Path to the JSON file for persisting jobs
             on_job: Callback for job execution
@@ -143,6 +143,7 @@ class CronService:
         self.on_job = on_job
         self._store: Optional[CronStore] = None
         self._timer_task: Optional[asyncio.Task] = None
+        self._file_watcher_task: Optional[asyncio.Task] = None
         self._running = False
     
     def _load_store(self) -> CronStore:
@@ -179,12 +180,14 @@ class CronService:
     async def start(self) -> None:
         """Start the cron service."""
         self._running = True
+        # Force reload store to clear cache (important for restart scenarios)
+        self._store = None
         self._load_store()
         self._recompute_next_runs()
         self._save_store()
         self._arm_timer()
         self._start_file_watcher()
-        
+
         job_count = len(self._store.jobs) if self._store else 0
         logger.info(f"Cron service started with {job_count} jobs")
     
@@ -194,6 +197,9 @@ class CronService:
         if self._timer_task:
             self._timer_task.cancel()
             self._timer_task = None
+        if self._file_watcher_task:
+            self._file_watcher_task.cancel()
+            self._file_watcher_task = None
         logger.info("Cron service stopped")
     
     def _start_file_watcher(self) -> None:
@@ -218,10 +224,10 @@ class CronService:
                             self._arm_timer()
                 except Exception as e:
                     logger.error(f"Cron file watcher error: {e}")
-                
+
                 await asyncio.sleep(5)  # Check every 5 seconds
-        
-        asyncio.create_task(watch_file())
+
+        self._file_watcher_task = asyncio.create_task(watch_file())
     
     def _recompute_next_runs(self) -> None:
         """Recompute next run times for all enabled jobs."""


### PR DESCRIPTION
Fix cron service restart issues (next run time & file watcher lifecycle)
修复 cron 服务重启问题（下次执行时间 & 文件监视器生命周期）

```bash
iflow-bot gateway restart
iflow-bot cron list
```